### PR TITLE
Update observer-mode-switch-lag-fix.sp - fix invalid client error

### DIFF
--- a/observer-mode-switch-lag-fix.sp
+++ b/observer-mode-switch-lag-fix.sp
@@ -35,6 +35,9 @@ public Action Timer_ChangeObserverMode(Handle timer, DataPack pack)
 
 public Action CommandListener_SpecNextPrev(int client, const char[] command, int args)
 {
+	if(!IsClientInGame(client))
+		return Plugin_Handled;
+
 	//PrintToConsole(client, "_SpecNextPrev = %s", command);
 	int iObserverMode = GetEntProp(client, Prop_Send, "m_iObserverMode");
 

--- a/observer-mode-switch-lag-fix.sp
+++ b/observer-mode-switch-lag-fix.sp
@@ -35,8 +35,8 @@ public Action Timer_ChangeObserverMode(Handle timer, DataPack pack)
 
 public Action CommandListener_SpecNextPrev(int client, const char[] command, int args)
 {
-	if(!IsClientInGame(client))
-		return Plugin_Handled;
+	if (!IsClientInGame(client))
+		return Plugin_Continue;
 
 	//PrintToConsole(client, "_SpecNextPrev = %s", command);
 	int iObserverMode = GetEntProp(client, Prop_Send, "m_iObserverMode");


### PR DESCRIPTION
L 04/13/2026 - 15:44:35: [SM] Exception reported: Entity -1 (3) is invalid
L 04/13/2026 - 15:44:35: [SM] Blaming: obsmodefix.smx
L 04/13/2026 - 15:44:35: [SM] Call stack trace:
L 04/13/2026 - 15:44:35: [SM]   [0] GetEntProp
L 04/13/2026 - 15:44:35: [SM]   [1] Line 40, obsmodefix.sp::CommandListener_SpecNextPrev